### PR TITLE
feat: Add config flow for Notification Catcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,12 @@ After installation (either via HACS or manually) and restarting Home Assistant:
     *   Go to **Settings > Devices & Services** in Home Assistant.
     *   Click **+ ADD INTEGRATION**.
     *   Search for "Notification Catcher" and select it.
-    *   A new sensor entity named `sensor.last_notification` (or similar, depending on your entity naming) will be created.
+    *   Follow the on-screen prompts. Since there are no configuration options in this version, it should be a simple confirmation step.
+2.  **Sensor Creation:**
+    *   Once added, a sensor entity named `sensor.last_notification` (or similar, depending on your entity naming conventions and if you rename it) will be created.
+    *   This sensor listens to the hardcoded MQTT topic: `notification_catcher/notify`.
 
-    *(Self-correction: The current `__init__.py` and `sensor.py` structure will automatically set up the sensor upon HA start if MQTT is configured. A config flow isn't strictly implemented yet for setting the MQTT topic, so the integration might not appear in "Add Integration" search immediately unless we add a `config_flow.py`. For now, the sensor should appear automatically after restart once the component is installed, using the default topic.)*
-
-    **Revised Configuration Note:**
-    The component currently uses a hardcoded MQTT topic: `notification_catcher/notify`.
-    Once the component is installed and Home Assistant is restarted, the `sensor.last_notification` entity should become available automatically, provided your MQTT integration is correctly set up in Home Assistant. No further UI configuration for the component itself is needed at this stage.
+Your Home Assistant instance must have the MQTT integration configured and connected to your MQTT broker for this component to function.
 
 ## Sending Notifications
 

--- a/custom_components/notification_catcher/config_flow.py
+++ b/custom_components/notification_catcher/config_flow.py
@@ -1,0 +1,64 @@
+"""Config flow for Notification Catcher integration."""
+import logging
+
+from homeassistant import config_entries
+from homeassistant.core import callback
+import voluptuous as vol
+
+from .const import DOMAIN  # Make sure .const has DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+class NotificationCatcherConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Notification Catcher."""
+
+    VERSION = 1
+    CONNECTION_CLASS = config_entries.CONN_CLASS_LOCAL_PUSH
+
+    async def async_step_user(self, user_input=None):
+        """Handle the initial step."""
+        if self._async_current_entries():
+            # Config entry already exists, only one instance allowed
+            return self.async_abort(reason="single_instance_allowed")
+
+        if user_input is not None:
+            # No data to store from the user in this simple case
+            _LOGGER.info("Setting up Notification Catcher integration")
+            return self.async_create_entry(title="Notification Catcher", data={})
+
+        # Show a form to the user to confirm setup.
+        # Since there's no input, it's just a confirmation.
+        return self.async_show_form(
+            step_id="user",
+            data_schema=None, # No fields needed
+            description_placeholders={
+                "docs_url": "https://github.com/your_username/ha-notification-catcher#readme"
+                # Replace with actual docs url or remove if not needed for form
+            },
+            errors={}, # No errors to show initially
+        )
+
+    # Example of how to implement options flow if you add configurable settings later
+    # @staticmethod
+    # @callback
+    # def async_get_options_flow(config_entry):
+    #    return NotificationCatcherOptionsFlowHandler(config_entry)
+
+# class NotificationCatcherOptionsFlowHandler(config_entries.OptionsFlow):
+#    def __init__(self, config_entry: config_entries.ConfigEntry):
+#        self.config_entry = config_entry
+#
+#    async def async_step_init(self, user_input=None):
+#        # Manage the options for the integration.
+#        # Example: allow users to update MQTT topic via UI
+#        if user_input is not None:
+#            # Validate and store options
+#            return self.async_create_entry(title="", data=user_input)
+#
+#        options_schema = vol.Schema({
+#            vol.Optional(
+#                "mqtt_topic",
+#                default=self.config_entry.options.get("mqtt_topic", "notification_catcher/default_topic")
+#            ): str
+#        })
+#        return self.async_show_form(step_id="init", data_schema=options_schema)


### PR DESCRIPTION
This commit introduces a configuration flow (`config_flow.py`) for the Notification Catcher custom component.

This allows you to add and set up the integration through the Home Assistant UI (Settings > Devices & Services), resolving an issue where the component could not be configured.

The config flow is basic:
- Allows only a single instance of the integration.
- Does not take any of your input as settings like the MQTT topic are currently hardcoded.
- Creates a config entry to enable Home Assistant to load the component.

The `README.md` has also been updated to reflect these new setup instructions.